### PR TITLE
Implement bundled plugin registry and improve multi-error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - TBD
+
+### Fixed
+
+- **Plugin System Functionality**: Implemented bundled registry for immediate plugin system functionality
+  - Created bundled `registry.json` with 4 official plugins (Vault, AWS Secrets, Azure Key Vault, Remote Config)
+  - Introduced `builtin://` URL scheme for plugins shipped with TripWire
+  - Plugin CLI commands now work out of the box (`search`, `install`, `list`, `remove`)
+  - Falls back to bundled registry when remote registry is unavailable
+  - All plugins marked as "(bundled)" in plugin list output
+  - Forward compatible with future PyPI-based plugin distribution (v0.11.0+)
+  - Zero hosting costs - registry bundled with package
+  - Offline-capable - works without network access
+  - Comprehensive test coverage (60+ new tests)
+
+- **Multi-Error UX Improvement**: Eliminated confusing "Exception ignored in atexit callback" messages
+  - Changed atexit finalization to use `os._exit(1)` instead of raising exceptions
+  - Clean stderr output without Python tracebacks
+  - Proper exit code (1) on validation failures
+  - Professional error presentation for production applications
+  - Manual `finalize()` still raises exceptions for testing compatibility
+
+### Technical Details
+
+- Added bundled registry fallback system (Remote → Cache → Bundled)
+- Implemented builtin plugin installer with dynamic import
+- Enhanced CLI list command with plugin type indicators
+- Package configuration updated to include registry.json in wheel
+- All official plugins installable via `tripwire plugin install <name>`
+
 ## [0.10.2] - 2025-10-14
 
 ### Added

--- a/examples/fastapi-example.py
+++ b/examples/fastapi-example.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+
+from tripwire import env
+
+# Validation happens HERE at import time - app won't start if invalid
+DATABASE_URL: str = env.require("DATABASE_URL", format="postgresql")
+PORT: int = env.require("PORT", min_val=1, max_val=65535)
+SECRET_KEY: str = env.require("SECRET_KEY", min_length=32, secret=True)
+DEBUG: bool = env.optional("DEBUG", default=False)
+
+app = FastAPI(debug=DEBUG)
+
+
+@app.on_event("startup")
+async def startup():
+    # By this point, we KNOW config is valid
+    print(f"Connecting to {DATABASE_URL[:20]}...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,17 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/tripwire"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/tripwire/plugins/data/registry.json" = "tripwire/plugins/data/registry.json"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/tests",
+    "/docs",
+    "src/tripwire/plugins/data/*.json"
+]
+
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/tripwire/cli/commands/plugin/ls.py
+++ b/src/tripwire/cli/commands/plugin/ls.py
@@ -1,5 +1,8 @@
 """Plugin list command for TripWire CLI."""
 
+import json
+from pathlib import Path
+
 import click
 from rich.console import Console
 from rich.table import Table
@@ -56,16 +59,23 @@ def list_plugins(details: bool) -> None:
             table.add_column("Name", style="green", width=20)
             table.add_column("Display Name", style="bold", width=25)
             table.add_column("Version", style="yellow", width=10)
+            table.add_column("Type", width=12)
             table.add_column("Author", width=20)
             table.add_column("License", width=12)
 
             for plugin_id in sorted(installed):
+                # Check if bundled plugin
+                plugin_dir = installer.PLUGINS_DIR / plugin_id
+                builtin_marker = plugin_dir / ".builtin"
+                plugin_type = "(bundled)" if builtin_marker.exists() else "(installed)"
+
                 plugin_entry = registry.get_plugin(plugin_id)
                 if plugin_entry:
                     table.add_row(
                         plugin_entry.name,
                         plugin_entry.display_name,
                         plugin_entry.latest_version,
+                        plugin_type,
                         plugin_entry.author,
                         plugin_entry.license,
                     )
@@ -75,6 +85,7 @@ def list_plugins(details: bool) -> None:
                         plugin_id,
                         plugin_id,
                         "unknown",
+                        "(custom)",
                         "unknown",
                         "unknown",
                     )
@@ -84,7 +95,11 @@ def list_plugins(details: bool) -> None:
             # Simple list
             console.print("[bold]Installed Plugins:[/bold]\n")
             for plugin_id in sorted(installed):
-                console.print(f"  [green]✓[/green] {plugin_id}")
+                # Check if bundled plugin
+                plugin_dir = installer.PLUGINS_DIR / plugin_id
+                builtin_marker = plugin_dir / ".builtin"
+                indicator = "[dim](bundled)[/dim]" if builtin_marker.exists() else ""
+                console.print(f"  [green]✓[/green] {plugin_id} {indicator}")
 
             console.print(
                 f"\n[cyan]Total:[/cyan] {len(installed)} plugin{'s' if len(installed) != 1 else ''} installed"

--- a/src/tripwire/plugins/data/registry.json
+++ b/src/tripwire/plugins/data/registry.json
@@ -1,0 +1,153 @@
+{
+  "version": "1.0.0",
+  "schema_version": "1.0",
+  "updated_at": "2025-10-14T00:00:00Z",
+  "description": "Bundled plugin registry for TripWire official plugins",
+  "plugins": {
+    "vault": {
+      "name": "vault",
+      "display_name": "HashiCorp Vault",
+      "description": "Load environment variables from HashiCorp Vault KV secrets engine (v1 and v2). Supports token-based authentication with HTTPS enforcement for production security.",
+      "author": "TripWire Team",
+      "author_email": "noreply@tripwire.dev",
+      "homepage": "https://github.com/Daily-Nerd/TripWire",
+      "repository": "https://github.com/Daily-Nerd/TripWire",
+      "license": "MIT",
+      "tags": [
+        "secrets",
+        "vault",
+        "hashicorp",
+        "cloud",
+        "kv",
+        "authentication",
+        "official"
+      ],
+      "versions": {
+        "1.0.0": {
+          "version": "1.0.0",
+          "release_date": "2025-10-14",
+          "min_tripwire_version": "0.10.0",
+          "max_tripwire_version": null,
+          "download_url": "builtin://tripwire.plugins.sources.vault/VaultEnvSource",
+          "checksum": "",
+          "downloads": 0
+        }
+      },
+      "latest_version": "1.0.0",
+      "total_downloads": 0,
+      "created_at": "2025-10-14T00:00:00Z",
+      "updated_at": "2025-10-14T00:00:00Z",
+      "official": true,
+      "bundled": true
+    },
+    "aws-secrets": {
+      "name": "aws-secrets",
+      "display_name": "AWS Secrets Manager",
+      "description": "Integrate with AWS Secrets Manager to load secrets. Supports IAM roles, credentials, and profiles. Automatically parses JSON secrets into environment variables.",
+      "author": "TripWire Team",
+      "author_email": "noreply@tripwire.dev",
+      "homepage": "https://github.com/Daily-Nerd/TripWire",
+      "repository": "https://github.com/Daily-Nerd/TripWire",
+      "license": "MIT",
+      "tags": [
+        "secrets",
+        "aws",
+        "cloud",
+        "amazon",
+        "iam",
+        "secretsmanager",
+        "official"
+      ],
+      "versions": {
+        "1.0.0": {
+          "version": "1.0.0",
+          "release_date": "2025-10-14",
+          "min_tripwire_version": "0.10.0",
+          "max_tripwire_version": null,
+          "download_url": "builtin://tripwire.plugins.sources.aws_secrets/AWSSecretsSource",
+          "checksum": "",
+          "downloads": 0
+        }
+      },
+      "latest_version": "1.0.0",
+      "total_downloads": 0,
+      "created_at": "2025-10-14T00:00:00Z",
+      "updated_at": "2025-10-14T00:00:00Z",
+      "official": true,
+      "bundled": true
+    },
+    "azure-keyvault": {
+      "name": "azure-keyvault",
+      "display_name": "Azure Key Vault",
+      "description": "Load secrets from Azure Key Vault with DefaultAzureCredential authentication. Supports service principals, managed identity, Azure CLI, and more. Automatically converts Azure naming conventions to environment variables.",
+      "author": "TripWire Team",
+      "author_email": "noreply@tripwire.dev",
+      "homepage": "https://github.com/Daily-Nerd/TripWire",
+      "repository": "https://github.com/Daily-Nerd/TripWire",
+      "license": "MIT",
+      "tags": [
+        "secrets",
+        "azure",
+        "cloud",
+        "microsoft",
+        "keyvault",
+        "managed-identity",
+        "official"
+      ],
+      "versions": {
+        "1.0.0": {
+          "version": "1.0.0",
+          "release_date": "2025-10-14",
+          "min_tripwire_version": "0.10.0",
+          "max_tripwire_version": null,
+          "download_url": "builtin://tripwire.plugins.sources.azure_keyvault/AzureKeyVaultSource",
+          "checksum": "",
+          "downloads": 0
+        }
+      },
+      "latest_version": "1.0.0",
+      "total_downloads": 0,
+      "created_at": "2025-10-14T00:00:00Z",
+      "updated_at": "2025-10-14T00:00:00Z",
+      "official": true,
+      "bundled": true
+    },
+    "remote-config": {
+      "name": "remote-config",
+      "display_name": "Remote HTTP Config",
+      "description": "Fetch configuration from any HTTP/REST API endpoint. Supports JSON and YAML formats with Bearer token, API key, or custom header authentication. HTTPS enforced for production security.",
+      "author": "TripWire Team",
+      "author_email": "noreply@tripwire.dev",
+      "homepage": "https://github.com/Daily-Nerd/TripWire",
+      "repository": "https://github.com/Daily-Nerd/TripWire",
+      "license": "MIT",
+      "tags": [
+        "config",
+        "remote",
+        "http",
+        "api",
+        "rest",
+        "json",
+        "yaml",
+        "official"
+      ],
+      "versions": {
+        "1.0.0": {
+          "version": "1.0.0",
+          "release_date": "2025-10-14",
+          "min_tripwire_version": "0.10.0",
+          "max_tripwire_version": null,
+          "download_url": "builtin://tripwire.plugins.sources.remote_config/RemoteConfigSource",
+          "checksum": "",
+          "downloads": 0
+        }
+      },
+      "latest_version": "1.0.0",
+      "total_downloads": 0,
+      "created_at": "2025-10-14T00:00:00Z",
+      "updated_at": "2025-10-14T00:00:00Z",
+      "official": true,
+      "bundled": true
+    }
+  }
+}

--- a/tests/plugins/test_builtin_install.py
+++ b/tests/plugins/test_builtin_install.py
@@ -1,0 +1,366 @@
+"""Tests for builtin plugin installation system."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tripwire.plugins.registry import (
+    PluginInstaller,
+    PluginRegistryClient,
+    PluginRegistryEntry,
+    PluginRegistryIndex,
+    PluginVersionInfo,
+)
+
+
+class TestBuiltinPluginInstallation:
+    """Test installing builtin plugins."""
+
+    @pytest.fixture
+    def bundled_registry(self):
+        """Get bundled registry with real plugins."""
+        client = PluginRegistryClient()
+        return client._load_bundled_registry()
+
+    @pytest.fixture
+    def installer(self, tmp_path, bundled_registry):
+        """Create installer with bundled registry."""
+        mock_client = MagicMock(spec=PluginRegistryClient)
+        mock_client.fetch_registry.return_value = bundled_registry
+
+        installer = PluginInstaller(mock_client)
+        installer.PLUGINS_DIR = tmp_path
+        return installer
+
+    def test_install_vault_builtin_plugin(self, installer, bundled_registry):
+        """Test installing Vault builtin plugin."""
+        plugin_dir = installer.install("vault")
+
+        # Check plugin directory created
+        assert plugin_dir.exists()
+        assert plugin_dir.is_dir()
+
+        # Check .builtin marker file exists
+        builtin_marker = plugin_dir / ".builtin"
+        assert builtin_marker.exists()
+
+        # Check metadata in .builtin file
+        with open(builtin_marker, "r") as f:
+            metadata = json.load(f)
+
+        assert metadata["name"] == "vault"
+        assert metadata["display_name"] == "HashiCorp Vault"
+        assert metadata["bundled"] is True
+        assert metadata["official"] is True
+        assert "install_url" in metadata
+        assert metadata["install_url"].startswith("builtin://")
+        assert metadata["module_path"] == "tripwire.plugins.sources.vault"
+        assert metadata["class_name"] == "VaultEnvSource"
+
+    def test_install_aws_secrets_builtin_plugin(self, installer, bundled_registry):
+        """Test installing AWS Secrets Manager builtin plugin."""
+        plugin_dir = installer.install("aws-secrets")
+
+        assert plugin_dir.exists()
+
+        builtin_marker = plugin_dir / ".builtin"
+        assert builtin_marker.exists()
+
+        with open(builtin_marker, "r") as f:
+            metadata = json.load(f)
+
+        assert metadata["name"] == "aws-secrets"
+        assert metadata["module_path"] == "tripwire.plugins.sources.aws_secrets"
+        assert metadata["class_name"] == "AWSSecretsSource"
+
+    def test_install_azure_keyvault_builtin_plugin(self, installer, bundled_registry):
+        """Test installing Azure Key Vault builtin plugin."""
+        plugin_dir = installer.install("azure-keyvault")
+
+        assert plugin_dir.exists()
+
+        builtin_marker = plugin_dir / ".builtin"
+        assert builtin_marker.exists()
+
+        with open(builtin_marker, "r") as f:
+            metadata = json.load(f)
+
+        assert metadata["name"] == "azure-keyvault"
+        assert metadata["module_path"] == "tripwire.plugins.sources.azure_keyvault"
+        assert metadata["class_name"] == "AzureKeyVaultSource"
+
+    def test_install_remote_config_builtin_plugin(self, installer, bundled_registry):
+        """Test installing Remote HTTP Config builtin plugin."""
+        plugin_dir = installer.install("remote-config")
+
+        assert plugin_dir.exists()
+
+        builtin_marker = plugin_dir / ".builtin"
+        assert builtin_marker.exists()
+
+        with open(builtin_marker, "r") as f:
+            metadata = json.load(f)
+
+        assert metadata["name"] == "remote-config"
+        assert metadata["module_path"] == "tripwire.plugins.sources.remote_config"
+        assert metadata["class_name"] == "RemoteConfigSource"
+
+    def test_builtin_plugin_already_installed(self, installer, bundled_registry):
+        """Test that installing already installed builtin plugin fails without force."""
+        # Install once
+        installer.install("vault")
+
+        # Try to install again without force
+        with pytest.raises(RuntimeError, match="already installed"):
+            installer.install("vault")
+
+    def test_builtin_plugin_force_reinstall(self, installer, bundled_registry):
+        """Test force reinstalling builtin plugin."""
+        # Install once
+        plugin_dir = installer.install("vault")
+        first_metadata_file = plugin_dir / ".builtin"
+
+        # Get install time from first installation
+        with open(first_metadata_file, "r") as f:
+            first_metadata = json.load(f)
+        first_install_time = first_metadata["installed_at"]
+
+        # Force reinstall
+        plugin_dir = installer.install("vault", force=True)
+
+        # Check it was reinstalled (new install time)
+        with open(first_metadata_file, "r") as f:
+            second_metadata = json.load(f)
+        second_install_time = second_metadata["installed_at"]
+
+        # Install times should be different (though very close)
+        # We can't guarantee they're different due to timestamp precision,
+        # but metadata should still be valid
+        assert plugin_dir.exists()
+        assert first_metadata_file.exists()
+
+    def test_builtin_plugin_import_validation(self, installer, bundled_registry):
+        """Test that builtin plugins can actually be imported."""
+        installer.install("vault")
+
+        # Try to import the plugin class
+        from tripwire.plugins.sources.vault import VaultEnvSource
+
+        assert VaultEnvSource is not None
+        assert hasattr(VaultEnvSource, "load")
+
+    def test_all_bundled_plugins_installable(self, installer, bundled_registry):
+        """Test that all bundled plugins can be installed."""
+        expected_plugins = ["vault", "aws-secrets", "azure-keyvault", "remote-config"]
+
+        for plugin_id in expected_plugins:
+            plugin_dir = installer.install(plugin_id)
+            assert plugin_dir.exists()
+
+            builtin_marker = plugin_dir / ".builtin"
+            assert builtin_marker.exists()
+
+    def test_builtin_plugin_list_shows_installed(self, installer, bundled_registry):
+        """Test that installed builtin plugins appear in list."""
+        # Install a few plugins
+        installer.install("vault")
+        installer.install("aws-secrets")
+
+        installed = installer.list_installed()
+
+        assert "vault" in installed
+        assert "aws-secrets" in installed
+        assert len(installed) == 2
+
+    def test_builtin_plugin_is_installed_check(self, installer, bundled_registry):
+        """Test checking if builtin plugin is installed."""
+        assert not installer.is_installed("vault")
+
+        installer.install("vault")
+
+        assert installer.is_installed("vault")
+
+    def test_builtin_plugin_uninstall(self, installer, bundled_registry):
+        """Test uninstalling builtin plugin."""
+        # Install plugin
+        plugin_dir = installer.install("vault")
+        assert plugin_dir.exists()
+        assert installer.is_installed("vault")
+
+        # Uninstall
+        installer.uninstall("vault")
+
+        assert not plugin_dir.exists()
+        assert not installer.is_installed("vault")
+
+
+class TestBuiltinURLParsing:
+    """Test parsing of builtin:// URLs."""
+
+    def test_parse_builtin_url(self):
+        """Test parsing valid builtin URL."""
+        url = "builtin://tripwire.plugins.sources.vault/VaultEnvSource"
+
+        assert url.startswith("builtin://")
+
+        url_path = url.replace("builtin://", "")
+        module_path, class_name = url_path.rsplit("/", 1)
+
+        assert module_path == "tripwire.plugins.sources.vault"
+        assert class_name == "VaultEnvSource"
+
+    def test_invalid_builtin_url_no_slash(self):
+        """Test handling of invalid builtin URL without slash."""
+        url = "builtin://tripwire.plugins.sources.vault"
+
+        url_path = url.replace("builtin://", "")
+
+        # Should not contain "/"
+        assert "/" not in url_path
+
+    def test_builtin_url_various_plugins(self):
+        """Test parsing builtin URLs for all official plugins."""
+        urls = {
+            "vault": "builtin://tripwire.plugins.sources.vault/VaultEnvSource",
+            "aws-secrets": "builtin://tripwire.plugins.sources.aws_secrets/AWSSecretsSource",
+            "azure-keyvault": "builtin://tripwire.plugins.sources.azure_keyvault/AzureKeyVaultSource",
+            "remote-config": "builtin://tripwire.plugins.sources.remote_config/RemoteConfigSource",
+        }
+
+        for plugin_id, url in urls.items():
+            url_path = url.replace("builtin://", "")
+            module_path, class_name = url_path.rsplit("/", 1)
+
+            # Validate structure
+            assert module_path.startswith("tripwire.plugins.sources.")
+            assert class_name.endswith("Source")
+
+
+class TestBuiltinPluginErrorHandling:
+    """Test error handling in builtin plugin installation."""
+
+    @pytest.fixture
+    def installer_with_bad_url(self, tmp_path):
+        """Create installer with invalid builtin URL."""
+        # Create registry with invalid builtin URL
+        version = PluginVersionInfo(
+            version="1.0.0",
+            release_date="2025-01-01",
+            min_tripwire_version="0.10.0",
+            download_url="builtin://invalid.module/InvalidClass",
+        )
+
+        entry = PluginRegistryEntry(
+            name="bad-plugin",
+            display_name="Bad Plugin",
+            description="Plugin with invalid module",
+            author="Test",
+            author_email="test@example.com",
+            homepage="https://example.com",
+            repository="https://example.com",
+            license="MIT",
+            versions={"1.0.0": version},
+            latest_version="1.0.0",
+        )
+
+        registry = PluginRegistryIndex(
+            version="1.0.0",
+            updated_at="2025-01-01T00:00:00Z",
+            plugins={"bad-plugin": entry},
+        )
+
+        mock_client = MagicMock(spec=PluginRegistryClient)
+        mock_client.fetch_registry.return_value = registry
+
+        installer = PluginInstaller(mock_client)
+        installer.PLUGINS_DIR = tmp_path
+        return installer
+
+    def test_builtin_plugin_invalid_module(self, installer_with_bad_url):
+        """Test error when builtin plugin module doesn't exist."""
+        with pytest.raises(RuntimeError, match="Failed to import builtin plugin"):
+            installer_with_bad_url.install("bad-plugin")
+
+    @pytest.fixture
+    def installer_with_bad_class(self, tmp_path):
+        """Create installer with invalid class name."""
+        version = PluginVersionInfo(
+            version="1.0.0",
+            release_date="2025-01-01",
+            min_tripwire_version="0.10.0",
+            download_url="builtin://tripwire.plugins.sources.vault/NonExistentClass",
+        )
+
+        entry = PluginRegistryEntry(
+            name="bad-class-plugin",
+            display_name="Bad Class Plugin",
+            description="Plugin with invalid class",
+            author="Test",
+            author_email="test@example.com",
+            homepage="https://example.com",
+            repository="https://example.com",
+            license="MIT",
+            versions={"1.0.0": version},
+            latest_version="1.0.0",
+        )
+
+        registry = PluginRegistryIndex(
+            version="1.0.0",
+            updated_at="2025-01-01T00:00:00Z",
+            plugins={"bad-class-plugin": entry},
+        )
+
+        mock_client = MagicMock(spec=PluginRegistryClient)
+        mock_client.fetch_registry.return_value = registry
+
+        installer = PluginInstaller(mock_client)
+        installer.PLUGINS_DIR = tmp_path
+        return installer
+
+    def test_builtin_plugin_invalid_class(self, installer_with_bad_class):
+        """Test error when builtin plugin class doesn't exist."""
+        with pytest.raises(RuntimeError, match="Plugin class .* not found"):
+            installer_with_bad_class.install("bad-class-plugin")
+
+
+class TestBuiltinPluginIntegration:
+    """Integration tests for builtin plugin system."""
+
+    def test_end_to_end_builtin_plugin_workflow(self, tmp_path):
+        """Test complete workflow: fetch registry → install plugin → use plugin."""
+        # Use real registry client to get bundled registry
+        client = PluginRegistryClient()
+        client.CACHE_DIR = tmp_path / "cache"
+        client.CACHE_FILE = client.CACHE_DIR / "registry.json"
+
+        # Block network to force bundled registry
+        with pytest.MonkeyPatch().context() as m:
+
+            def mock_urlopen(*args, **kwargs):
+                raise Exception("Network blocked for test")
+
+            m.setattr("urllib.request.urlopen", mock_urlopen)
+
+            # Fetch registry (should use bundled)
+            registry = client.fetch_registry(use_cache=False)
+
+        # Create installer
+        installer = PluginInstaller(client)
+        installer.PLUGINS_DIR = tmp_path / "plugins"
+
+        # Install builtin plugin
+        plugin_dir = installer.install("vault")
+
+        # Verify installation
+        assert plugin_dir.exists()
+        assert (plugin_dir / ".builtin").exists()
+
+        # Verify plugin is listed
+        assert "vault" in installer.list_installed()
+
+        # Verify plugin can be imported
+        from tripwire.plugins.sources.vault import VaultEnvSource
+
+        assert VaultEnvSource is not None

--- a/tests/plugins/test_bundled_registry.py
+++ b/tests/plugins/test_bundled_registry.py
@@ -1,0 +1,300 @@
+"""Tests for bundled plugin registry system."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tripwire.plugins.registry import PluginRegistryClient
+
+
+class TestBundledRegistry:
+    """Test bundled registry functionality."""
+
+    def test_bundled_registry_exists(self):
+        """Test that bundled registry file exists in package."""
+        client = PluginRegistryClient()
+        assert client.BUNDLED_REGISTRY_PATH.exists(), (
+            f"Bundled registry not found at {client.BUNDLED_REGISTRY_PATH}. "
+            "This indicates package corruption or incomplete build."
+        )
+
+    def test_bundled_registry_valid_json(self):
+        """Test that bundled registry is valid JSON."""
+        client = PluginRegistryClient()
+        with open(client.BUNDLED_REGISTRY_PATH, "r") as f:
+            registry_data = json.load(f)
+
+        # Validate structure
+        assert "version" in registry_data
+        assert "plugins" in registry_data
+        assert isinstance(registry_data["plugins"], dict)
+
+    def test_bundled_registry_has_official_plugins(self):
+        """Test that bundled registry contains all 4 official plugins."""
+        client = PluginRegistryClient()
+        with open(client.BUNDLED_REGISTRY_PATH, "r") as f:
+            registry_data = json.load(f)
+
+        plugins = registry_data["plugins"]
+
+        # Check all 4 official plugins are present
+        expected_plugins = ["vault", "aws-secrets", "azure-keyvault", "remote-config"]
+        for plugin_id in expected_plugins:
+            assert plugin_id in plugins, f"Official plugin '{plugin_id}' missing from bundled registry"
+
+    def test_bundled_registry_plugins_have_builtin_urls(self):
+        """Test that bundled plugins use builtin:// URLs."""
+        client = PluginRegistryClient()
+        with open(client.BUNDLED_REGISTRY_PATH, "r") as f:
+            registry_data = json.load(f)
+
+        plugins = registry_data["plugins"]
+
+        for plugin_id, plugin_data in plugins.items():
+            versions = plugin_data.get("versions", {})
+            for version_id, version_data in versions.items():
+                download_url = version_data.get("download_url", "")
+                assert download_url.startswith(
+                    "builtin://"
+                ), f"Plugin '{plugin_id}' version '{version_id}' does not use builtin:// URL"
+
+    def test_bundled_registry_plugins_marked_as_official(self):
+        """Test that bundled plugins are marked as official."""
+        client = PluginRegistryClient()
+        with open(client.BUNDLED_REGISTRY_PATH, "r") as f:
+            registry_data = json.load(f)
+
+        plugins = registry_data["plugins"]
+
+        for plugin_id, plugin_data in plugins.items():
+            assert plugin_data.get("official") is True, f"Plugin '{plugin_id}' not marked as official"
+            assert plugin_data.get("bundled") is True, f"Plugin '{plugin_id}' not marked as bundled"
+
+    def test_load_bundled_registry(self):
+        """Test loading bundled registry."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        assert registry is not None
+        assert registry.version is not None
+        assert len(registry.plugins) >= 4  # At least 4 official plugins
+
+    def test_bundled_registry_metadata_complete(self):
+        """Test that bundled registry has complete metadata for all plugins."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        required_fields = ["name", "display_name", "description", "author", "license"]
+
+        for plugin_id, plugin_entry in registry.plugins.items():
+            for field in required_fields:
+                value = getattr(plugin_entry, field, None)
+                assert value, f"Plugin '{plugin_id}' missing required field '{field}'"
+
+    def test_bundled_registry_versions_valid(self):
+        """Test that bundled registry versions have valid metadata."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        for plugin_id, plugin_entry in registry.plugins.items():
+            assert plugin_entry.latest_version, f"Plugin '{plugin_id}' missing latest_version"
+            assert plugin_entry.versions, f"Plugin '{plugin_id}' has no versions"
+
+            # Check latest version exists in versions dict
+            latest_version_info = plugin_entry.get_version()
+            assert latest_version_info is not None, f"Plugin '{plugin_id}' latest version not in versions dict"
+
+
+class TestBundledRegistryFallback:
+    """Test bundled registry fallback behavior."""
+
+    def test_fallback_to_bundled_when_remote_fails(self, tmp_path):
+        """Test that bundled registry is used when remote fetch fails."""
+        client = PluginRegistryClient()
+        client.CACHE_DIR = tmp_path
+        client.CACHE_FILE = tmp_path / "registry.json"
+
+        # Mock network failure
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            registry = client.fetch_registry(use_cache=False)
+
+        # Should fall back to bundled registry
+        assert registry is not None
+        assert len(registry.plugins) >= 4  # Official plugins
+
+    def test_fallback_priority_remote_cache_bundled(self, tmp_path):
+        """Test fallback priority: Remote → Cache → Bundled."""
+        client = PluginRegistryClient()
+        client.CACHE_DIR = tmp_path
+        client.CACHE_FILE = tmp_path / "registry.json"
+
+        # Create cache with custom data
+        cache_data = {
+            "version": "1.0.0",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "plugins": {
+                "test-plugin": {
+                    "name": "test-plugin",
+                    "display_name": "Test Plugin",
+                    "description": "Test plugin from cache",
+                    "author": "Test Author",
+                    "author_email": "test@example.com",
+                    "homepage": "https://example.com",
+                    "repository": "https://example.com",
+                    "license": "MIT",
+                    "versions": {
+                        "1.0.0": {
+                            "version": "1.0.0",
+                            "release_date": "2025-01-01",
+                            "min_tripwire_version": "0.10.0",
+                            "download_url": "https://example.com/plugin.tar.gz",
+                        }
+                    },
+                    "latest_version": "1.0.0",
+                }
+            },
+        }
+
+        with open(client.CACHE_FILE, "w") as f:
+            json.dump(cache_data, f)
+
+        # Mock remote failure
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            registry = client.fetch_registry(use_cache=True)
+
+        # Should use cache (priority 2)
+        assert "test-plugin" in registry.plugins
+
+    def test_bundled_registry_always_available(self, tmp_path):
+        """Test that bundled registry is always available as last resort."""
+        client = PluginRegistryClient()
+        client.CACHE_DIR = tmp_path
+        client.CACHE_FILE = tmp_path / "registry.json"
+
+        # No cache file, no remote access
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            registry = client.fetch_registry(use_cache=False)
+
+        # Should still work via bundled registry
+        assert registry is not None
+        assert len(registry.plugins) >= 4
+
+    def test_bundled_registry_offline_mode(self, tmp_path):
+        """Test that plugin system works completely offline."""
+        client = PluginRegistryClient()
+        client.CACHE_DIR = tmp_path
+        client.CACHE_FILE = tmp_path / "registry.json"
+
+        # Ensure no cache exists
+        if client.CACHE_FILE.exists():
+            client.CACHE_FILE.unlink()
+
+        # Block all network access
+        with patch("urllib.request.urlopen", side_effect=Exception("Offline mode")):
+            registry = client.fetch_registry(use_cache=False)
+
+        # Should work with bundled registry
+        assert registry is not None
+
+        # Should have official plugins
+        assert "vault" in registry.plugins
+        assert "aws-secrets" in registry.plugins
+        assert "azure-keyvault" in registry.plugins
+        assert "remote-config" in registry.plugins
+
+    def test_bundled_registry_missing_raises_error(self, tmp_path):
+        """Test that missing bundled registry raises clear error."""
+        client = PluginRegistryClient()
+        client.CACHE_DIR = tmp_path
+        client.CACHE_FILE = tmp_path / "registry.json"
+
+        # Point to non-existent bundled registry
+        client.BUNDLED_REGISTRY_PATH = tmp_path / "nonexistent.json"
+
+        # Block network and ensure no cache
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            with pytest.raises(RuntimeError, match="Failed to fetch plugin registry"):
+                client.fetch_registry(use_cache=False)
+
+
+class TestBundledRegistryPluginInfo:
+    """Test plugin information in bundled registry."""
+
+    def test_vault_plugin_metadata(self):
+        """Test HashiCorp Vault plugin metadata."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        vault = registry.get_plugin("vault")
+        assert vault is not None
+        assert vault.name == "vault"
+        assert vault.display_name == "HashiCorp Vault"
+        assert "vault" in vault.description.lower()
+        assert vault.author == "TripWire Team"
+        assert vault.license == "MIT"
+        assert "vault" in vault.tags
+        assert "hashicorp" in vault.tags
+
+    def test_aws_secrets_plugin_metadata(self):
+        """Test AWS Secrets Manager plugin metadata."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        aws = registry.get_plugin("aws-secrets")
+        assert aws is not None
+        assert aws.name == "aws-secrets"
+        assert aws.display_name == "AWS Secrets Manager"
+        assert "aws" in aws.description.lower()
+        assert aws.author == "TripWire Team"
+        assert aws.license == "MIT"
+        assert "aws" in aws.tags
+
+    def test_azure_keyvault_plugin_metadata(self):
+        """Test Azure Key Vault plugin metadata."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        azure = registry.get_plugin("azure-keyvault")
+        assert azure is not None
+        assert azure.name == "azure-keyvault"
+        assert azure.display_name == "Azure Key Vault"
+        assert "azure" in azure.description.lower()
+        assert azure.author == "TripWire Team"
+        assert azure.license == "MIT"
+        assert "azure" in azure.tags
+
+    def test_remote_config_plugin_metadata(self):
+        """Test Remote HTTP Config plugin metadata."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        remote = registry.get_plugin("remote-config")
+        assert remote is not None
+        assert remote.name == "remote-config"
+        assert remote.display_name == "Remote HTTP Config"
+        assert "http" in remote.description.lower() or "api" in remote.description.lower()
+        assert remote.author == "TripWire Team"
+        assert remote.license == "MIT"
+        assert "http" in remote.tags or "api" in remote.tags
+
+    def test_plugin_search_works_with_bundled(self):
+        """Test search functionality works with bundled registry."""
+        client = PluginRegistryClient()
+        registry = client._load_bundled_registry()
+
+        # Search for various terms
+        vault_results = registry.search("vault")
+        assert len(vault_results) > 0
+        assert any(p.name == "vault" for p in vault_results)
+
+        aws_results = registry.search("aws")
+        assert len(aws_results) > 0
+        assert any(p.name == "aws-secrets" for p in aws_results)
+
+        secrets_results = registry.search("secrets")
+        assert len(secrets_results) >= 3  # vault, aws-secrets, azure-keyvault
+
+        cloud_results = registry.search("cloud")
+        assert len(cloud_results) >= 3  # All cloud providers

--- a/uv.lock
+++ b/uv.lock
@@ -1607,7 +1607,7 @@ wheels = [
 
 [[package]]
 name = "tripwire-py"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request delivers major improvements to the TripWire plugin system, focusing on immediate out-of-the-box functionality, robust offline support, and enhanced error handling. The highlights include bundling a registry of official plugins with the package, introducing a new plugin discovery and installation workflow, and refining the user experience for multi-error validation scenarios. These changes also improve the CLI output and package configuration to support the new features.

**Plugin System Enhancements:**

* Bundled registry system: Added a bundled `registry.json` containing four official plugins (Vault, AWS Secrets, Azure Key Vault, Remote Config), with a new `builtin://` URL scheme for plugins shipped with TripWire. The plugin CLI now works out of the box and falls back to the bundled registry if the remote registry is unavailable, ensuring zero hosting costs and offline capability. All plugins are marked as "(bundled)" in CLI outputs. [[1]](diffhunk://#diff-de1303755d74891d92e256ce48852cbf01ed3faae883f20c71a796af42c25fe7R1-R153) [[2]](diffhunk://#diff-fd74bcb6e5c5244e9b125aaff0602fc6b3d4d783c88d227aeb0aae08e1e7b847R306-R316) [[3]](diffhunk://#diff-fd74bcb6e5c5244e9b125aaff0602fc6b3d4d783c88d227aeb0aae08e1e7b847L323-R330) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R67-R77) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R39)

* Plugin discovery and installation: Updated the plugin system to discover plugins both from setuptools entry points and installed bundled plugins, skipping validation for bundled plugins and directly registering them for immediate use. [[1]](diffhunk://#diff-d45f36851e1053e5e13145980ba52d90dfa524f30c67e297db13e66f9713bee4L214-R218) [[2]](diffhunk://#diff-d45f36851e1053e5e13145980ba52d90dfa524f30c67e297db13e66f9713bee4L234-R252) [[3]](diffhunk://#diff-d45f36851e1053e5e13145980ba52d90dfa524f30c67e297db13e66f9713bee4R345-R403)

* CLI improvements: Enhanced the plugin list command to display plugin type indicators ("(bundled)", "(installed)", "(custom)") and improved output formatting for clarity. [[1]](diffhunk://#diff-67b0e059166537632ae414e0288f278767b795cf4f95d606a07b0e200d91f0efR3-R5) [[2]](diffhunk://#diff-67b0e059166537632ae414e0288f278767b795cf4f95d606a07b0e200d91f0efR62-R78) [[3]](diffhunk://#diff-67b0e059166537632ae414e0288f278767b795cf4f95d606a07b0e200d91f0efR88) [[4]](diffhunk://#diff-67b0e059166537632ae414e0288f278767b795cf4f95d606a07b0e200d91f0efL87-R102)

**Multi-Error Handling Improvements:**

* Refined error finalization: Changed atexit finalization to print errors to stderr and exit with code 1 using `os._exit(1)`, eliminating confusing "Exception ignored in atexit callback" messages and ensuring clean error output for production. Manual finalization still raises exceptions for testing or explicit control. [[1]](diffhunk://#diff-30a83db7aa2897be469bcb7f5bc043783c072eca61fcac35d756a4f0404a1a8aL1011-R1021) [[2]](diffhunk://#diff-30a83db7aa2897be469bcb7f5bc043783c072eca61fcac35d756a4f0404a1a8aL1031-R1065) [[3]](diffhunk://#diff-30a83db7aa2897be469bcb7f5bc043783c072eca61fcac35d756a4f0404a1a8aL1054-R1094) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R39)

**Packaging and Example Updates:**

* Package configuration: Updated `pyproject.toml` to include the bundled registry in wheels and source distributions, ensuring the registry is always available.

* Added FastAPI example: Provided a new example demonstrating TripWire usage with FastAPI, showing validation at import time.