### PR TITLE
fix(ci): release.yml accepts dynamic CLI version sourced from __version__

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,9 +108,13 @@ jobs:
             exit 1
           fi
 
-          # Check cli/__init__.py version using Python for more reliable parsing (v0.7.0+ modular structure)
-          CLI_VERSION=$(python3 -c "import re; content=open('src/tripwire/cli/__init__.py').read(); match=re.search(r'@click\.version_option\(version=\"([^\"]+)\"', content); print(match.group(1) if match else '')")
-          if [ "$VERSION" != "$CLI_VERSION" ]; then
+          # Check cli/__init__.py version. v1.0.0+ sources from `__version__`, so a
+          # reference is acceptable (validated transitively via __init__.py above).
+          # Otherwise expect a literal string and match it against the tag.
+          CLI_VERSION=$(python3 -c "import re; content=open('src/tripwire/cli/__init__.py').read(); m=re.search(r'@click\.version_option\(version=([^,)]+)', content); raw=(m.group(1).strip() if m else ''); print('__DYNAMIC__' if raw and not raw.startswith('\"') else (raw.strip('\"') if raw else ''))")
+          if [ "$CLI_VERSION" = "__DYNAMIC__" ]; then
+            echo "✓ cli/__init__.py sources version dynamically (validated via __init__.py)"
+          elif [ "$VERSION" != "$CLI_VERSION" ]; then
             echo "::error::Version mismatch: tag=$VERSION but cli/__init__.py=$CLI_VERSION"
             exit 1
           fi


### PR DESCRIPTION
## Summary

The v1.0.0 tag push (PR #62 squash-merge) failed at the `Verify version consistency` step in `release.yml`. PyPI was **not** published — the workflow halted before any upload, and the tag has been deleted from the remote.

The check expects `cli/__init__.py` to contain a literal version string in `@click.version_option(version="X.Y.Z", ...)`. v1.0.0 changed it to `version=__version__` so the CLI never drifts again — but the regex captured an empty string and reported `tag=1.0.0 but cli/__init__.py=`.

## Fix

The CLI version check now treats a non-literal value (any expression that isn't a quoted string) as `__DYNAMIC__` and accepts it as valid. The dynamic value is already validated transitively, because the previous step in the same job verifies that `__init__.py`'s `__version__` matches the tag — and `cli/__init__.py` imports `__version__` from there.

## After this merges

1. Tag `v1.0.0` from `main`
2. Tag push triggers `release.yml` end-to-end (validate → tests → build → Test PyPI → PyPI → GitHub Release)

## Test plan

- [x] Regex change verified locally — outputs `__DYNAMIC__` for the current `cli/__init__.py`
- [ ] Confirmed by the next `release.yml` run when `v1.0.0` is re-tagged after merge