### PR TITLE
fix(build): drop force-include directive, ship JSON via include pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,16 +63,18 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tripwire"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/tripwire/plugins/data/registry.json" = "tripwire/plugins/data/registry.json"
+# Non-Python package data (JSON, etc.) ships automatically via the `packages`
+# directive above. Avoid `force-include` here — it materialises files directly
+# into site-packages and creates a namespace-package shadow that breaks
+# editable installs (`python -m tripwire.cli` becomes unfindable mid-session).
+include = ["src/tripwire/**/*.json"]
 
 [tool.hatch.build.targets.sdist]
 include = [
     "/src",
     "/tests",
     "/docs",
-    "src/tripwire/plugins/data/*.json"
+    "src/tripwire/plugins/data/*.json",
 ]
 
 


### PR DESCRIPTION
## Summary

The \`[tool.hatch.build.targets.wheel.force-include]\` directive in \`pyproject.toml\` was used to ship \`plugins/data/registry.json\` inside the wheel. As an unintended side effect, hatch materialised the file at \`.venv/lib/.../site-packages/tripwire/plugins/data/registry.json\` during editable installs (\`uv sync\` and \`pip install -e .\`).

Python then treated \`site-packages/tripwire/\` as a **namespace package** (since it contained no \`__init__.py\`), which shadowed the editable-install pointer (\`_editable_impl_tripwire_py.pth\`) on import. Subprocess imports like \`python -m tripwire.cli\` failed with:

\`\`\`
ModuleNotFoundError: No module named 'tripwire.cli'
\`\`\`

This bit us during the v1.0.0 release work and is reproducible on any contributor's machine after a local version bump or reinstall.

## Fix

Replace \`force-include\` with a plain \`include\` pattern:

\`\`\`toml
[tool.hatch.build.targets.wheel]
packages = [\"src/tripwire\"]
include = [\"src/tripwire/**/*.json\"]
\`\`\`

The wheel and sdist still contain \`tripwire/plugins/data/registry.json\`. The shadow directory no longer materialises in site-packages during editable installs.

## Verification

- **Wheel** inspected with \`python -m zipfile -l\`: contains \`tripwire/plugins/data/registry.json\`
- **Sdist** inspected with \`tarfile\`: contains \`src/tripwire/plugins/data/registry.json\`
- After \`uv sync --reinstall-package tripwire-py\`: \`site-packages/tripwire/\` directory no longer exists (only the editable-install \`.pth\` and the dist-info dir remain)
- \`python -m tripwire.cli --version\` → \`Version: 1.0.0\` cleanly
- \`uv run --frozen pytest --no-cov\` → **2111 passed, 1 skipped, 0 failed**

## Why this matters

This was **Risk D** in the v1.0.0 archaeology report. Without this fix, every contributor running \`uv sync\` after a version transition (or any environment churn) would hit obscure \`ModuleNotFoundError\` failures during \`pytest\`, with no obvious cause from the user's perspective. We just lived through it once.