### PR TITLE
fix(git_audit): redact pickaxe secret in errors, drop spurious raise on stream early-exit

### DIFF
--- a/src/tripwire/git_audit.py
+++ b/src/tripwire/git_audit.py
@@ -245,6 +245,27 @@ def _estimate_occurrence_size(occurrence: FileOccurrence) -> int:
     return size
 
 
+def _redact_git_args(args: List[str]) -> List[str]:
+    """Return a copy of git arg list with sensitive flag values masked.
+
+    Currently masks the value following ``-G`` and ``-S`` (pickaxe flags) and
+    ``--grep``, since those flags carry secret values or fragments thereof
+    when they originate from audit code paths. The redacted form is suitable
+    for embedding in user-visible error messages.
+    """
+    redacted: List[str] = []
+    skip_next = False
+    for arg in args:
+        if skip_next:
+            redacted.append("***")
+            skip_next = False
+            continue
+        redacted.append(arg)
+        if arg in ("-G", "-S", "--grep"):
+            skip_next = True
+    return redacted
+
+
 def run_git_command(
     args: List[str],
     repo_path: Path,
@@ -283,15 +304,17 @@ def run_git_command(
 
         if check and result.returncode != 0:
             raise GitCommandError(
-                command=" ".join(["git"] + args),
+                command=" ".join(["git"] + _redact_git_args(args)),
                 stderr=result.stderr,
                 returncode=result.returncode,
             )
 
         return result
     except subprocess.TimeoutExpired:
-        # Log timeout and re-raise with context
-        raise RuntimeError(f"Git command timed out after {timeout}s: git {' '.join(args)}") from None
+        # Log timeout and re-raise with context (redacted)
+        raise RuntimeError(
+            f"Git command timed out after {timeout}s: git {' '.join(_redact_git_args(args))}"
+        ) from None
     except FileNotFoundError as e:
         raise GitCommandError(command="git", stderr=str(e), returncode=127) from e
 
@@ -617,6 +640,7 @@ def audit_secret_stream(
         text=True,
     )
 
+    terminated_by_us = False
     try:
         count = 0
         for line in proc.stdout:  # type: ignore[union-attr]
@@ -634,8 +658,11 @@ def audit_secret_stream(
             count += 1
 
     finally:
-        # CRITICAL: Terminate process if iteration stopped early
+        # CRITICAL: Terminate process if iteration stopped early.
+        # Track that we initiated the termination so the post-finally returncode
+        # check below does not misread our SIGTERM as a real git failure.
         if proc.poll() is None:  # Still running
+            terminated_by_us = True
             proc.terminate()
             try:
                 proc.wait(timeout=5)
@@ -643,8 +670,10 @@ def audit_secret_stream(
                 proc.kill()
                 proc.wait()
 
-    # Check for errors after completion
-    if proc.returncode and proc.returncode != 0:
+    # Check for errors after completion. A non-zero returncode caused by our
+    # own terminate() (count >= max_commits, or caller closing the generator)
+    # is expected and must not raise.
+    if not terminated_by_us and proc.returncode is not None and proc.returncode > 0:
         stderr = proc.stderr.read() if proc.stderr else ""
         raise GitCommandError(
             command="git log -G",

--- a/src/tripwire/git_audit.py
+++ b/src/tripwire/git_audit.py
@@ -104,7 +104,11 @@ def sanitize_git_pattern(pattern: str, max_length: int = _MAX_PATTERN_LENGTH) ->
     bounded_repetition_match = re.search(r"\{(\d+)(?:,(\d+))?\}", pattern)
     if bounded_repetition_match:
         min_count = int(bounded_repetition_match.group(1))
-        max_count = int(bounded_repetition_match.group(2)) if bounded_repetition_match.group(2) else min_count
+        max_count = (
+            int(bounded_repetition_match.group(2))
+            if bounded_repetition_match.group(2)
+            else min_count
+        )
 
         # If repetition count is > 1000, it's potentially dangerous
         if max_count > 1000 or min_count > 1000:
@@ -1019,7 +1023,10 @@ def generate_filter_branch_command(files: List[str]) -> str:
     """
     # Properly escape each file path to prevent shell injection
     files_str = " ".join(shlex.quote(f) for f in files)
-    return f"git filter-branch --force --index-filter " f"'git rm --cached --ignore-unmatch {files_str}' HEAD"
+    return (
+        f"git filter-branch --force --index-filter "
+        f"'git rm --cached --ignore-unmatch {files_str}' HEAD"
+    )
 
 
 def get_rotation_command(secret_name: str) -> Optional[str]:
@@ -1094,7 +1101,9 @@ def generate_remediation_steps(
 
     # Step 2: Remove from git history if found in commits
     if timeline.commits_affected:
-        rewrite_cmd, tool_name, tool_warning = generate_history_rewrite_command(timeline.files_affected)
+        rewrite_cmd, tool_name, tool_warning = generate_history_rewrite_command(
+            timeline.files_affected
+        )
         steps.append(
             RemediationStep(
                 order=2,
@@ -1131,7 +1140,8 @@ def generate_remediation_steps(
             order=4,
             title="Update .gitignore",
             description=(
-                "Ensure .env and other secret files are in .gitignore " "to prevent future accidental commits."
+                "Ensure .env and other secret files are in .gitignore "
+                "to prevent future accidental commits."
             ),
             urgency="MEDIUM",
             command="echo '.env\n.env.local' >> .gitignore",

--- a/src/tripwire/git_audit.py
+++ b/src/tripwire/git_audit.py
@@ -104,11 +104,7 @@ def sanitize_git_pattern(pattern: str, max_length: int = _MAX_PATTERN_LENGTH) ->
     bounded_repetition_match = re.search(r"\{(\d+)(?:,(\d+))?\}", pattern)
     if bounded_repetition_match:
         min_count = int(bounded_repetition_match.group(1))
-        max_count = (
-            int(bounded_repetition_match.group(2))
-            if bounded_repetition_match.group(2)
-            else min_count
-        )
+        max_count = int(bounded_repetition_match.group(2)) if bounded_repetition_match.group(2) else min_count
 
         # If repetition count is > 1000, it's potentially dangerous
         if max_count > 1000 or min_count > 1000:
@@ -316,9 +312,7 @@ def run_git_command(
         return result
     except subprocess.TimeoutExpired:
         # Log timeout and re-raise with context (redacted)
-        raise RuntimeError(
-            f"Git command timed out after {timeout}s: git {' '.join(_redact_git_args(args))}"
-        ) from None
+        raise RuntimeError(f"Git command timed out after {timeout}s: git {' '.join(_redact_git_args(args))}") from None
     except FileNotFoundError as e:
         raise GitCommandError(command="git", stderr=str(e), returncode=127) from e
 
@@ -1023,10 +1017,7 @@ def generate_filter_branch_command(files: List[str]) -> str:
     """
     # Properly escape each file path to prevent shell injection
     files_str = " ".join(shlex.quote(f) for f in files)
-    return (
-        f"git filter-branch --force --index-filter "
-        f"'git rm --cached --ignore-unmatch {files_str}' HEAD"
-    )
+    return f"git filter-branch --force --index-filter " f"'git rm --cached --ignore-unmatch {files_str}' HEAD"
 
 
 def get_rotation_command(secret_name: str) -> Optional[str]:
@@ -1101,9 +1092,7 @@ def generate_remediation_steps(
 
     # Step 2: Remove from git history if found in commits
     if timeline.commits_affected:
-        rewrite_cmd, tool_name, tool_warning = generate_history_rewrite_command(
-            timeline.files_affected
-        )
+        rewrite_cmd, tool_name, tool_warning = generate_history_rewrite_command(timeline.files_affected)
         steps.append(
             RemediationStep(
                 order=2,
@@ -1140,8 +1129,7 @@ def generate_remediation_steps(
             order=4,
             title="Update .gitignore",
             description=(
-                "Ensure .env and other secret files are in .gitignore "
-                "to prevent future accidental commits."
+                "Ensure .env and other secret files are in .gitignore " "to prevent future accidental commits."
             ),
             urgency="MEDIUM",
             command="echo '.env\n.env.local' >> .gitignore",

--- a/tests/test_git_audit.py
+++ b/tests/test_git_audit.py
@@ -17,6 +17,7 @@ from tripwire.git_audit import (
     RemediationStep,
     SecretTimeline,
     _is_valid_git_path,
+    _redact_git_args,
     analyze_secret_history,
     audit_secret_stream,
     check_filter_repo_available,
@@ -156,6 +157,46 @@ class TestGitCommands:
             run_git_command(["invalid-command"], temp_git_repo, check=True)
 
         assert "invalid-command" in str(exc_info.value)
+
+    def test_run_git_command_redacts_pickaxe_secret_in_error(
+        self, temp_git_repo: Path
+    ) -> None:
+        """The -G pickaxe value carries the literal secret. A failing git call
+        must NOT echo it back to the user — that defeats the audit's purpose.
+        """
+        secret_value = "AKIA-FAKE-SECRET-VALUE-1234567890"
+        with pytest.raises(GitCommandError) as exc_info:
+            # Force failure by pointing at a path that is not a git repo within
+            # the args so the command runs but the repo flag is what fails.
+            run_git_command(
+                ["log", "-G", secret_value, "--this-flag-does-not-exist"],
+                temp_git_repo,
+                check=True,
+            )
+
+        # The full error rendering (str + .command + .args of any wrapping
+        # exception) must not contain the raw secret.
+        rendered = str(exc_info.value)
+        assert secret_value not in rendered
+        assert "***" in rendered
+
+    def test_redact_git_args_masks_pickaxe_and_grep(self) -> None:
+        """Redaction helper covers -G, -S, and --grep."""
+        args = ["log", "-G", "secret-G", "-S", "secret-S", "--grep", "secret-grep"]
+        assert _redact_git_args(args) == [
+            "log",
+            "-G",
+            "***",
+            "-S",
+            "***",
+            "--grep",
+            "***",
+        ]
+
+    def test_redact_git_args_passes_innocuous_flags_through(self) -> None:
+        """Non-sensitive flags are unchanged."""
+        args = ["log", "--all", "--format=%H", "main"]
+        assert _redact_git_args(args) == args
 
     def test_check_git_repository_valid(self, temp_git_repo: Path) -> None:
         """Test checking a valid git repository."""
@@ -970,6 +1011,24 @@ class TestStreamingAudit:
 
         # Should still find at least one occurrence
         assert len(occurrences) >= 0
+
+    def test_audit_secret_stream_max_commits_no_spurious_error(
+        self, git_repo_with_secret: Path
+    ) -> None:
+        """Hitting max_commits triggers the finally `proc.terminate()` path.
+
+        Before the fix, the post-finally returncode check treated SIGTERM as a
+        git failure and raised `GitCommandError` to a caller that had asked for
+        a bounded scan. The completed iteration must NOT raise.
+        """
+        # Iterate to completion; should not raise.
+        list(
+            audit_secret_stream(
+                secret_name="AWS_SECRET_KEY",
+                repo_path=git_repo_with_secret,
+                max_commits=1,
+            )
+        )
 
     def test_audit_secret_stream_memory_efficiency(self, git_repo_with_secret: Path) -> None:
         """Test that streaming audit doesn't load all results into memory."""

--- a/tests/test_git_audit.py
+++ b/tests/test_git_audit.py
@@ -158,9 +158,7 @@ class TestGitCommands:
 
         assert "invalid-command" in str(exc_info.value)
 
-    def test_run_git_command_redacts_pickaxe_secret_in_error(
-        self, temp_git_repo: Path
-    ) -> None:
+    def test_run_git_command_redacts_pickaxe_secret_in_error(self, temp_git_repo: Path) -> None:
         """The -G pickaxe value carries the literal secret. A failing git call
         must NOT echo it back to the user — that defeats the audit's purpose.
         """
@@ -314,7 +312,9 @@ class TestSecretSearch:
         """Test that binary files are skipped."""
         # Create a fake binary file with the pattern
         (temp_git_repo / "image.png").write_bytes(b"AWS_SECRET_KEY=test")
-        subprocess.run(["git", "add", "image.png"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", "image.png"], cwd=temp_git_repo, check=True, capture_output=True
+        )
         subprocess.run(
             ["git", "commit", "-m", "Add image"],
             cwd=temp_git_repo,
@@ -781,7 +781,12 @@ class TestIntegration:
         config_file = git_repo_with_secret / "config.py"
         config_file.write_text("# Empty config\n")
 
-        subprocess.run(["git", "add", ".env", "config.py"], cwd=git_repo_with_secret, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", ".env", "config.py"],
+            cwd=git_repo_with_secret,
+            check=True,
+            capture_output=True,
+        )
         subprocess.run(
             ["git", "commit", "-m", "Remove secret from all files"],
             cwd=git_repo_with_secret,
@@ -891,7 +896,9 @@ class TestErrorHandling:
         """Test find_secret_in_commit skips empty file paths."""
         # Create a commit
         (temp_git_repo / "test.txt").write_text("SECRET=value\n")
-        subprocess.run(["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True
+        )
         subprocess.run(
             ["git", "commit", "-m", "Add test"],
             cwd=temp_git_repo,
@@ -924,7 +931,9 @@ class TestErrorHandling:
         """Test find_secret_in_commit handles file read errors."""
         # Create a commit
         (temp_git_repo / "test.txt").write_text("SECRET=value\n")
-        subprocess.run(["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True
+        )
         subprocess.run(
             ["git", "commit", "-m", "Add test"],
             cwd=temp_git_repo,

--- a/tests/test_git_audit.py
+++ b/tests/test_git_audit.py
@@ -312,9 +312,7 @@ class TestSecretSearch:
         """Test that binary files are skipped."""
         # Create a fake binary file with the pattern
         (temp_git_repo / "image.png").write_bytes(b"AWS_SECRET_KEY=test")
-        subprocess.run(
-            ["git", "add", "image.png"], cwd=temp_git_repo, check=True, capture_output=True
-        )
+        subprocess.run(["git", "add", "image.png"], cwd=temp_git_repo, check=True, capture_output=True)
         subprocess.run(
             ["git", "commit", "-m", "Add image"],
             cwd=temp_git_repo,
@@ -896,9 +894,7 @@ class TestErrorHandling:
         """Test find_secret_in_commit skips empty file paths."""
         # Create a commit
         (temp_git_repo / "test.txt").write_text("SECRET=value\n")
-        subprocess.run(
-            ["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True
-        )
+        subprocess.run(["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True)
         subprocess.run(
             ["git", "commit", "-m", "Add test"],
             cwd=temp_git_repo,
@@ -931,9 +927,7 @@ class TestErrorHandling:
         """Test find_secret_in_commit handles file read errors."""
         # Create a commit
         (temp_git_repo / "test.txt").write_text("SECRET=value\n")
-        subprocess.run(
-            ["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True
-        )
+        subprocess.run(["git", "add", "test.txt"], cwd=temp_git_repo, check=True, capture_output=True)
         subprocess.run(
             ["git", "commit", "-m", "Add test"],
             cwd=temp_git_repo,
@@ -1021,9 +1015,7 @@ class TestStreamingAudit:
         # Should still find at least one occurrence
         assert len(occurrences) >= 0
 
-    def test_audit_secret_stream_max_commits_no_spurious_error(
-        self, git_repo_with_secret: Path
-    ) -> None:
+    def test_audit_secret_stream_max_commits_no_spurious_error(self, git_repo_with_secret: Path) -> None:
         """Hitting max_commits triggers the finally `proc.terminate()` path.
 
         Before the fix, the post-finally returncode check treated SIGTERM as a


### PR DESCRIPTION
## Summary

Two real bugs in \`src/tripwire/git_audit.py\` surfaced by the post-v1.0.0 audit. Both are security/UX-relevant.

## Bug 1 — secret leak in \`GitCommandError\`

\`run_git_command\` built \`GitCommandError.command\` as \`\" \".join([\"git\"] + args)\`. In audit code paths, \`args\` contains \`[\"log\", \"-G\", <secret>, ...]\`. A failing invocation (timeout, bad ref, permission error) raised an exception whose \`__str__\` contained the plaintext secret. CLI handlers in \`cli/commands/security.py\` (audit handlers) print such exceptions directly to the terminal — leaking exactly the value the audit was trying to protect.

**Fix.** Introduced \`_redact_git_args\` that masks the value following \`-G\`, \`-S\`, and \`--grep\`. Both \`GitCommandError\` (line 285) and the timeout \`RuntimeError\` use the redacted form when embedding args into messages.

## Bug 2 — spurious \`GitCommandError\` on bounded stream completion

\`audit_secret_stream\` is a generator over \`git log -G\`. When \`count >= max_commits\`, the for-loop breaks normally; the \`finally\` block then calls \`proc.terminate()\`, which sets \`returncode\` to \`-15\` on Unix or \`1\` on Windows. The post-finally returncode check treated that as a real git failure and raised. A caller asking for a bounded scan with \`max_commits=N\` therefore received an exception instead of clean completion.

**Fix.** Track \`terminated_by_us = True\` before \`proc.terminate()\` and skip the returncode check when we initiated the SIGTERM. Also tightened the comparison to \`proc.returncode is not None and proc.returncode > 0\` so a negative signal exit is unambiguously ignored.

## Tests added

- \`test_run_git_command_redacts_pickaxe_secret_in_error\` — fails an audit-shaped command, asserts the literal secret does NOT appear in the rendered error and \`***\` does
- \`test_redact_git_args_masks_pickaxe_and_grep\` — unit test on the redaction helper
- \`test_redact_git_args_passes_innocuous_flags_through\` — guard against over-redaction
- \`test_audit_secret_stream_max_commits_no_spurious_error\` — drains a bounded stream, asserts no \`GitCommandError\` raises

## Verification

\`uv run --frozen pytest --no-cov\` → **2120 passed, 1 skipped, 0 failed** (was 2116 before this PR; +4 regression tests).