### PR TITLE
fix(core): validate the default value, not just the environment value

### DIFF
--- a/src/tripwire/core/tripwire_v2.py
+++ b/src/tripwire/core/tripwire_v2.py
@@ -566,7 +566,9 @@ class TripWireV2:
             >>> env = TripWireV2(auto_load=False)
             >>> env.load_files([".env", ".env.local", ".env.production"])
         """
-        sources: List[EnvSource] = [DotenvFileSource(Path(p), override=override) for p in file_paths]
+        sources: List[EnvSource] = [
+            DotenvFileSource(Path(p), override=override) for p in file_paths
+        ]
         temp_loader = EnvFileLoader(sources, strict=self.strict)
         temp_loader.load_all()
 

--- a/src/tripwire/core/tripwire_v2.py
+++ b/src/tripwire/core/tripwire_v2.py
@@ -374,9 +374,7 @@ class TripWireV2:
                     default_orchestrator.validate(default_context)
                     if default_orchestrator.has_errors():
                         with self._error_lock:
-                            self._validation_errors.extend(
-                                default_orchestrator.get_collected_errors()
-                            )
+                            self._validation_errors.extend(default_orchestrator.get_collected_errors())
                 else:
                     # Fail-fast: an invalid default raises immediately.
                     default_orchestrator.validate(default_context)
@@ -566,9 +564,7 @@ class TripWireV2:
             >>> env = TripWireV2(auto_load=False)
             >>> env.load_files([".env", ".env.local", ".env.production"])
         """
-        sources: List[EnvSource] = [
-            DotenvFileSource(Path(p), override=override) for p in file_paths
-        ]
+        sources: List[EnvSource] = [DotenvFileSource(Path(p), override=override) for p in file_paths]
         temp_loader = EnvFileLoader(sources, strict=self.strict)
         temp_loader.load_all()
 

--- a/src/tripwire/core/tripwire_v2.py
+++ b/src/tripwire/core/tripwire_v2.py
@@ -346,6 +346,40 @@ class TripWireV2:
         raw_value = os.getenv(name)
         if raw_value is None:
             if default is not None:
+                # Validate the default itself. Skipping this lets bugs like
+                # `default="not-a-number"` with `min_val=1` ship silently.
+                # The default is already a Python value of the inferred type
+                # per the signature, so coercion is a no-op; only the
+                # validation rules (format/pattern/choices/min/max/length/
+                # validator) need to run.
+                default_orchestrator = self._build_validation_pipeline(
+                    format=format,
+                    pattern=pattern,
+                    choices=choices,
+                    min_val=min_val,
+                    max_val=max_val,
+                    min_length=min_length,
+                    max_length=max_length,
+                    validator=validator,
+                    error_message=error_message,
+                )
+                default_context = ValidationContext(
+                    name=name,
+                    raw_value=str(default),
+                    coerced_value=default,
+                    expected_type=inferred_type,
+                )
+                if self.collect_errors:
+                    default_orchestrator.collect_errors = True
+                    default_orchestrator.validate(default_context)
+                    if default_orchestrator.has_errors():
+                        with self._error_lock:
+                            self._validation_errors.extend(
+                                default_orchestrator.get_collected_errors()
+                            )
+                else:
+                    # Fail-fast: an invalid default raises immediately.
+                    default_orchestrator.validate(default_context)
                 return default
 
             # Handle missing variable based on error collection mode

--- a/tests/core/test_tripwire_v2.py
+++ b/tests/core/test_tripwire_v2.py
@@ -120,6 +120,41 @@ class TestBasicFunctionality:
 
         assert TIMEOUT == 30
 
+    def test_default_value_runs_through_validation_pipeline(self, monkeypatch):
+        """A default that violates declared constraints must NOT slip through.
+
+        Before the fix, defaults were returned without validation, so a
+        statement like ``env.require("PORT", default=99999, max_val=65535)``
+        silently shipped an invalid value at import time. Now the same
+        validation rules that apply to environment values apply to defaults.
+        """
+        env = TripWireV2(auto_load=False, collect_errors=False)
+        monkeypatch.delenv("PORT", raising=False)
+
+        with pytest.raises(ValidationError):
+            env.require("PORT", default=99999, min_val=1, max_val=65535)
+
+    def test_default_value_violating_choices_raises(self, monkeypatch):
+        env = TripWireV2(auto_load=False, collect_errors=False)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+        with pytest.raises(ValidationError):
+            env.require("ENVIRONMENT", default="staging-typo", choices=["dev", "prod"])
+
+    def test_default_value_violating_format_raises(self, monkeypatch):
+        env = TripWireV2(auto_load=False, collect_errors=False)
+        monkeypatch.delenv("ADMIN_EMAIL", raising=False)
+
+        with pytest.raises(ValidationError):
+            env.require("ADMIN_EMAIL", default="not-an-email", format="email")
+
+    def test_default_value_passing_validation_returns_default(self, monkeypatch):
+        env = TripWireV2(auto_load=False, collect_errors=False)
+        monkeypatch.delenv("PORT", raising=False)
+
+        port = env.require("PORT", default=8000, min_val=1, max_val=65535)
+        assert port == 8000
+
     def test_alias_tripwire_is_v2(self):
         """Test that TripWire is an alias for TripWireV2."""
         assert TripWire is TripWireV2

--- a/tests/core/test_tripwire_v2.py
+++ b/tests/core/test_tripwire_v2.py
@@ -318,7 +318,9 @@ class TestValidation:
         env = TripWireV2(auto_load=False)
         monkeypatch.setenv("EMAIL", "test@example.com")
 
-        EMAIL: str = env.require("EMAIL", format="email", min_length=5, max_length=100, pattern=r".*@example\.com$")
+        EMAIL: str = env.require(
+            "EMAIL", format="email", min_length=5, max_length=100, pattern=r".*@example\.com$"
+        )
 
         assert EMAIL == "test@example.com"
 
@@ -379,7 +381,10 @@ class TestDependencyInjection:
         custom_loader = EnvFileLoader([], strict=False)
 
         env = TripWireV2(
-            registry=custom_registry, inference_engine=custom_engine, loader=custom_loader, auto_load=False
+            registry=custom_registry,
+            inference_engine=custom_engine,
+            loader=custom_loader,
+            auto_load=False,
         )
 
         monkeypatch.setenv("TEST", "value")

--- a/tests/core/test_tripwire_v2.py
+++ b/tests/core/test_tripwire_v2.py
@@ -318,9 +318,7 @@ class TestValidation:
         env = TripWireV2(auto_load=False)
         monkeypatch.setenv("EMAIL", "test@example.com")
 
-        EMAIL: str = env.require(
-            "EMAIL", format="email", min_length=5, max_length=100, pattern=r".*@example\.com$"
-        )
+        EMAIL: str = env.require("EMAIL", format="email", min_length=5, max_length=100, pattern=r".*@example\.com$")
 
         assert EMAIL == "test@example.com"
 


### PR DESCRIPTION
## Summary

\`TripWireV2.require()\` previously short-circuited as soon as a default was present, returning it without running any validation. A statement like

\`\`\`python
PORT: int = env.require(\"PORT\", default=99999, min_val=1, max_val=65535)
\`\`\`

silently shipped an invalid value at import time — the exact failure mode the library exists to prevent.

## Fix

Run defaults through the same validation pipeline as a real environment value (format / pattern / choices / min_val / max_val / min_length / max_length / validator). Coercion is skipped because the default is already a Python value of the inferred type per the public type signature; only the validation rules execute.

Behavior:

- \`collect_errors=False\` (the v0.13.1 default): an invalid default raises \`ValidationError\` immediately at the call site.
- \`collect_errors=True\`: the error is collected and reported with the rest of the validation errors at finalization.

## Tests

Added in \`tests/core/test_tripwire_v2.py\`:

- \`test_default_value_runs_through_validation_pipeline\` — min/max bound
- \`test_default_value_violating_choices_raises\`
- \`test_default_value_violating_format_raises\`
- \`test_default_value_passing_validation_returns_default\`

## Verification

\`uv run --frozen pytest --no-cov\` → **2120 passed, 1 skipped, 0 failed**.

## Compatibility note

This is a behavior change for users who rely on invalid defaults being returned silently. That reliance is itself a bug; the migration is to either fix the default, or pass \`collect_errors=True\` and inspect the collected error report.