### PR TITLE
security: use tarfile.extractall(filter='data') when available (Py3.1…

### DIFF
--- a/src/tripwire/plugins/registry.py
+++ b/src/tripwire/plugins/registry.py
@@ -98,7 +98,12 @@ def _safe_extract_tarfile(tar: tarfile.TarFile, target_dir: Path) -> None:
             )
 
     # All paths validated, safe to extract
-    tar.extractall(target_dir)  # nosec B202  # Path traversal validated above via _is_safe_path()
+    try:
+        # Python 3.12+: safe extract avoids metadata surprises on 3.14
+        tar.extractall(target_dir, filter="data")  # nosec B202  # _is_safe_path ensures safety
+    except TypeError:
+        # Older Python: no filter arg
+        tar.extractall(target_dir)  # nosec B202  # _is_safe_path ensures safety
 
 
 def _safe_extract_zipfile(zip_file: zipfile.ZipFile, target_dir: Path) -> None:


### PR DESCRIPTION
Description                                                                                                                                                                                         
 Use tarfile.extractall(filter="data") when available to align with Python 3.14 default tarfile filter behavior. Keep existing path traversal protections (_is_safe_path) and fall back to           
 extractall() without filter on older Pythons.                                                                                                                                                       
 Type of Change                                                                                                                                                                                      
 - [x] Bug fix                                                                                                                                                                                       
 - [x] Security                                                                                                                                                                                      
 Related Issues                                                                                                                                                                                      
 N/A                                                                                                                                                                                                 
 Changes Made                                                                                                                                                                                        
 - src/tripwire/plugins/registry.py:                                                                                                                                                                 
   - Wrap extraction in try/except TypeError                                                                                                                                                         
   - Prefer extractall(filter="data") on 3.12+, fallback to extractall() on older versions                                                                                                           
 Testing                                                                                                                                                                                             
 - [x] Existing tests pass                                                                                                                                                                           
 - [x] Targeted test for safe extraction passes:                                                                                                                                                     
   - tests/plugins/test_plugin_registry_security.py::TestSafeTarfileExtraction::test_safe_extract_tarfile_valid_archive                                                                              
 Code Quality                                                                                                                                                                                        
 - [x] Style and comments                                                                                                                                                                            
 - [x] Minimal change set                                                                                                                                                                            
 Security                                                                                                                                                                                            
 - [x] No sensitive data                                                                                                                                                                             
 - [x] Strengthens extraction safety and future-compatibility                                                                                                                                        
 Documentation                                                                                                                                                                                       
 - [x] N/A                                                                                                                                                                                           
 Performance                                                                                                                                                                                         
 - [x] No measurable impact                                                                                                                                                                          
 Breaking Changes                                                                                                                                                                                    
 None                                                                                                                                                                                                
 Screenshots/Examples                                                                                                                                                                                
 N/A                                                                                                                                                                                                 
 Checklist                                                                                                                                                                                           
 - [x] Style guidelines                                                                                                                                                                              
 - [x] Tests pass                                                                                                                                                                                    
 Additional Notes                                                                                                                                                                                    
 Maintains existing traversal guards; change targets Py3.14 compatibility.