### PR TITLE
fix: use release-please manifest for versions only

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,3 @@
 {
-  ".": {
-    "changelog-path": "CHANGELOG.md",
-    "release-type": "python",
-    "component": "tripwire-py"
-  }
+  ".": "1.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,21 +9,61 @@
       "package-name": "tripwire-py",
       "release-type": "python",
       "extra-files": [
-        "pyproject.toml",
-        "src/tripwire/__init__.py"
+        "pyproject.toml"
       ],
       "changelog-types": [
-        {"type": "feat",     "section": "Features",          "hidden": false},
-        {"type": "fix",      "section": "Bug Fixes",         "hidden": false},
-        {"type": "perf",     "section": "Performance",       "hidden": false},
-        {"type": "refactor", "section": "Refactoring",       "hidden": false},
-        {"type": "docs",     "section": "Documentation",     "hidden": false},
-        {"type": "test",     "section": "Tests",            "hidden": false},
-        {"type": "ci",       "section": "CI",               "hidden": true},
-        {"type": "build",    "section": "Build System",      "hidden": true},
-        {"type": "chore",    "section": "Chores",           "hidden": true},
-        {"type": "revert",   "section": "Reverts",          "hidden": false}
-      ]
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "perf",
+          "section": "Performance",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Refactoring",
+          "hidden": false
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": false
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": false
+        },
+        {
+          "type": "ci",
+          "section": "CI",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "section": "Chores",
+          "hidden": true
+        },
+        {
+          "type": "revert",
+          "section": "Reverts",
+          "hidden": false
+        }
+      ],
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the release configuration files to simplify the release manifest and improve the structure and clarity of the release-please configuration. The main changes involve streamlining the `.release-please-manifest.json` file and reformatting the `release-please-config.json` for better maintainability.

**Release configuration updates:**

* Simplified the `.release-please-manifest.json` file by replacing the object with a direct version string, making the manifest more concise and easier to manage.
* Reformatted the `changelog-types` array in `release-please-config.json` to use a more readable object-per-line style, which enhances clarity and maintainability.
* Removed `src/tripwire/__init__.py` from the `extra-files` list in `release-please-config.json`, so only `pyproject.toml` is now tracked as an extra file for releases.
* Explicitly added the `changelog-path` setting to `release-please-config.json` to ensure the changelog is generated at `CHANGELOG.md`.