### PR TITLE
fix: derive __version__ from package metadata for release-please comp…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,12 +106,8 @@ jobs:
             exit 1
           fi
 
-          # Check __init__.py version
-          INIT_VERSION=$(grep '^__version__ = ' src/tripwire/__init__.py | sed 's/__version__ = "\(.*\)"/\1/')
-          if [ "$VERSION" != "$INIT_VERSION" ]; then
-            echo "::error::Version mismatch: tag=$VERSION but __init__.py=$INIT_VERSION"
-            exit 1
-          fi
+          # __version__ is derived from package metadata when installed. Avoid a
+          # duplicated literal that Release Please must keep in sync.
 
           # Check cli/__init__.py version. v1.0.0+ sources from `__version__`, so a
           # reference is acceptable (validated transitively via __init__.py above).

--- a/src/tripwire/__init__.py
+++ b/src/tripwire/__init__.py
@@ -14,6 +14,8 @@ Advanced usage:
     >>> db_url = custom_env.require("DATABASE_URL", format="postgresql")
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from tripwire.core import TripWire, TripWireV2, env
 from tripwire.exceptions import (
     DriftError,
@@ -26,7 +28,10 @@ from tripwire.exceptions import (
 )
 from tripwire.validation import validator
 
-__version__ = "1.0.0"
+try:
+    __version__ = version("tripwire-py")
+except PackageNotFoundError:  # pragma: no cover - source tree fallback before installation
+    __version__ = "0+unknown"
 
 __all__ = [
     "TripWire",

--- a/uv.lock
+++ b/uv.lock
@@ -1737,7 +1737,7 @@ wheels = [
 
 [[package]]
 name = "tripwire-py"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request updates how the `__version__` attribute is managed in the `tripwire` package to avoid duplication and ensure consistency with the package metadata. The workflow no longer checks for a hardcoded version in `__init__.py`, and the version is now dynamically derived at runtime.

Version management improvements:

* The `__version__` attribute in `src/tripwire/__init__.py` is now set dynamically using `importlib.metadata.version("tripwire-py")`, with a fallback to `"0+unknown"` if the package is not installed. This prevents version mismatches and removes the need for manual updates. [[1]](diffhunk://#diff-b8c317e6dd0be18973052bcc28b4b912fdf26578c2d7f20d420498204102d8a9R17-R18) [[2]](diffhunk://#diff-b8c317e6dd0be18973052bcc28b4b912fdf26578c2d7f20d420498204102d8a9L29-R34)
* The release workflow in `.github/workflows/release.yml` no longer checks for a hardcoded version in `src/tripwire/__init__.py`, reflecting the shift to deriving the version from package metadata.