### PR TITLE
fix: anchor release-please at the 1.0.2 release PR

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "",
   "include-v-in-tag": true,
   "separate-pull-requests": false,
   "pull-request-title-pattern": "chore: release ${version}",
@@ -65,5 +64,6 @@
       ],
       "changelog-path": "CHANGELOG.md"
     }
-  }
+  },
+  "last-release-sha": "56b5ac6d33de37a4b0969d311958db7a02b56279"
 }


### PR DESCRIPTION
## Summary
- Anchors Release Please at the merged 1.0.2 release PR commit.
- Removes the empty bootstrap-sha value from the Release Please config.
- Prevents Release Please from backfilling historical commits into an unintended 2.0.0 release PR.

## Validation
- Parsed release-please-config.json successfully.
- Confirmed .release-please-manifest.json remains at 1.0.2.
