### PR TITLE
docs(ci): release docs + validator CI job

### DIFF
--- a/.github/scripts/validate_release_config.py
+++ b/.github/scripts/validate_release_config.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate TripWire release automation configuration.
+
+This script checks the Release Please state/config and the release workflows for
+regressions that have previously broken publishing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover
+    raise SystemExit("PyYAML is required to validate workflow YAML") from exc
+
+ROOT = Path(__file__).resolve().parents[2]
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+HEX_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}")
+    raise SystemExit(1)
+
+
+def load_json(relative: str) -> object:
+    path = ROOT / relative
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:  # noqa: BLE001 - show actionable file context
+        fail(f"{relative} is not valid JSON: {exc}")
+
+
+def load_yaml(relative: str) -> object:
+    path = ROOT / relative
+    try:
+        return yaml.safe_load(path.read_text())
+    except Exception as exc:  # noqa: BLE001 - show actionable file context
+        fail(f"{relative} is not valid YAML: {exc}")
+
+
+def load_text(relative: str) -> str:
+    return (ROOT / relative).read_text()
+
+
+def validate_manifest() -> str:
+    manifest = load_json(".release-please-manifest.json")
+    if not isinstance(manifest, dict):
+        fail(".release-please-manifest.json must be a JSON object")
+    if set(manifest) != {"."}:
+        fail(".release-please-manifest.json must contain exactly one key: '.'")
+    version = manifest["."]
+    if not isinstance(version, str) or not VERSION_RE.match(version):
+        fail(".release-please-manifest.json value for '.' must be a version string like 1.2.3")
+    return version
+
+
+def validate_pyproject(version: str) -> None:
+    pyproject = tomllib.loads(load_text("pyproject.toml"))
+    project = pyproject.get("project")
+    if not isinstance(project, dict):
+        fail("pyproject.toml is missing [project]")
+    pyproject_version = project.get("version")
+    if pyproject_version != version:
+        fail(
+            "pyproject.toml version must match .release-please-manifest.json: "
+            f"{pyproject_version!r} != {version!r}"
+        )
+
+
+def validate_release_please_config() -> None:
+    config = load_json("release-please-config.json")
+    if not isinstance(config, dict):
+        fail("release-please-config.json must be a JSON object")
+
+    if config.get("bootstrap-sha") == "":
+        fail('release-please-config.json must not contain empty "bootstrap-sha"')
+    for sha_key in ("bootstrap-sha", "last-release-sha"):
+        value = config.get(sha_key)
+        if value is not None and (not isinstance(value, str) or not HEX_SHA_RE.match(value)):
+            fail(f'release-please-config.json field "{sha_key}" must be a full 40-character SHA')
+
+    packages = config.get("packages")
+    if not isinstance(packages, dict) or set(packages) != {"."}:
+        fail('release-please-config.json must contain packages with exactly the root package "."')
+
+    package = packages["."]
+    if not isinstance(package, dict):
+        fail('release-please-config.json packages["."] must be an object')
+    expected = {
+        "package-name": "tripwire-py",
+        "release-type": "python",
+        "changelog-path": "CHANGELOG.md",
+    }
+    for key, expected_value in expected.items():
+        if package.get(key) != expected_value:
+            fail(f'release-please-config.json packages["."].{key} must be {expected_value!r}')
+
+    extra_files = package.get("extra-files")
+    if not isinstance(extra_files, list) or "pyproject.toml" not in extra_files:
+        fail('release-please-config.json packages["."].extra-files must include pyproject.toml')
+
+
+def validate_workflows() -> None:
+    release_workflow = load_yaml(".github/workflows/release.yml")
+    release_please_workflow = load_yaml(".github/workflows/release-please.yml")
+    if not isinstance(release_workflow, dict):
+        fail("release.yml must parse to a YAML object")
+    if not isinstance(release_please_workflow, dict):
+        fail("release-please.yml must parse to a YAML object")
+
+    release_text = load_text(".github/workflows/release.yml")
+    release_please_text = load_text(".github/workflows/release-please.yml")
+
+    required_release_snippets = [
+        "Install from Test PyPI in clean environment",
+        "python -m venv .venv_test",
+        "--index-url https://test.pypi.org/simple/",
+        "Resolve release tag",
+        "fail_on_unmatched_files: true",
+        "dist/*.whl",
+        "dist/*.tar.gz",
+    ]
+    for snippet in required_release_snippets:
+        if snippet not in release_text:
+            fail(f"release.yml missing required release hardening snippet: {snippet}")
+
+    forbidden_release_please_snippets = [
+        "uses: ./.github/workflows/release.yml",
+        "tripwire-release:",
+        "steps.release.outputs.tag_name ||",
+    ]
+    for snippet in forbidden_release_please_snippets:
+        if snippet in release_please_text:
+            fail(f"release-please.yml must not directly call release.yml or use stale output expression: {snippet}")
+
+    if "id-token: write" in release_please_text:
+        fail("release-please.yml should not request id-token: write when it does not publish directly")
+
+
+def main() -> None:
+    version = validate_manifest()
+    validate_pyproject(version)
+    validate_release_please_config()
+    validate_workflows()
+    print(f"✓ release configuration is valid for tripwire-py {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/validate_release_config.py
+++ b/.github/scripts/validate_release_config.py
@@ -143,8 +143,6 @@ def validate_workflows() -> None:
         if snippet in release_please_text:
             fail(f"release-please.yml must not directly call release.yml or use stale output expression: {snippet}")
 
-    if "id-token: write" in release_please_text:
-        fail("release-please.yml should not request id-token: write when it does not publish directly")
 
 
 def main() -> None:

--- a/.github/workflows/release-config-validate.yml
+++ b/.github/workflows/release-config-validate.yml
@@ -1,0 +1,48 @@
+name: Release Config Validate
+
+on:
+  push:
+    branches: [ main, feature/* ]
+    paths:
+      - ".github/workflows/release-config-validate.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-please.yml"
+      - ".github/scripts/validate_release_config.py"
+      - "release-please-config.json"
+      - ".release-please-manifest.json"
+      - "docs/RELEASING.md"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/release-config-validate.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-please.yml"
+      - ".github/scripts/validate_release_config.py"
+      - "release-please-config.json"
+      - ".release-please-manifest.json"
+      - "docs/RELEASING.md"
+
+jobs:
+  validate:
+    name: Validate Release Configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies (locked)
+        run: uv sync --frozen --all-extras
+
+      - name: Validate release configuration
+        run: uv run python .github/scripts/validate_release_config.py

--- a/.pre-commit-config.release-validate.yaml
+++ b/.pre-commit-config.release-validate.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: release-config-validate
+        name: Validate Release Configuration
+        entry: python .github/scripts/validate_release_config.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,116 @@
+# Releasing TripWire
+
+TripWire uses Release Please to prepare release pull requests and a separate GitHub Actions release workflow to build, verify, and publish distributions.
+
+## Normal release flow
+
+1. Merge regular feature and fix PRs into `main` using conventional commit style commit titles.
+2. Release Please runs on pushes to `main` and opens or updates a release PR.
+3. Review the release PR changelog and version bump.
+4. Merge the release PR when ready.
+5. Release Please creates the `vX.Y.Z` tag and GitHub Release.
+6. The `Release` workflow runs for the tag and publishes:
+   - build artifacts,
+   - TestPyPI package,
+   - PyPI package via Trusted Publishing,
+   - GitHub Release assets.
+
+## Conventional commits
+
+Release Please calculates SemVer bumps from conventional commit messages:
+
+- `fix: ...` -> patch release
+- `feat: ...` -> minor release
+- `type(scope)!: ...` or a `BREAKING CHANGE:` footer -> major release
+
+Use neutral public wording in commit titles and PR descriptions. Do not include private operational context, credentials, internal hostnames, or personal details in public repo content.
+
+## Release Please files
+
+### `.release-please-manifest.json`
+
+This file is Release Please version state only. Keep the shape simple:
+
+```json
+{
+  ".": "1.2.3"
+}
+```
+
+Do not put package metadata, changelog settings, release type, or component names in this file.
+
+### `release-please-config.json`
+
+This file contains Release Please configuration, including:
+
+- package name,
+- release type,
+- changelog sections,
+- extra version files,
+- release search/bootstrap controls.
+
+Do not leave `"bootstrap-sha": ""` in the config. If Release Please needs to be anchored after a recovery release, use a real full commit SHA and document why in the PR.
+
+## Required GitHub configuration
+
+### Secrets
+
+- `TEST_PYPI_API_TOKEN`: API token used by the TestPyPI upload step.
+
+### Environments
+
+- `pypi`: GitHub environment used by the PyPI Trusted Publishing job.
+
+### PyPI Trusted Publishing
+
+The PyPI project must trust this repository/workflow for OIDC publishing. The release workflow requests `id-token: write` only for the PyPI publish job.
+
+## Recovery: release PR merged but package was not published
+
+Use this flow if a release PR was merged but the publish workflow failed before PyPI upload.
+
+1. Fix the release workflow in a normal PR.
+2. Merge the fix.
+3. Manually dispatch the `Release` workflow:
+   - `version`: the intended release version, for example `1.0.2`
+   - `prerelease`: `false` for normal releases
+4. Watch all release jobs until complete.
+5. Verify:
+   - `https://pypi.org/project/tripwire-py/<version>/` exists,
+   - `https://github.com/Daily-Nerd/TripWire/releases/tag/v<version>` exists,
+   - release assets include wheel and sdist.
+
+The release workflow intentionally allows manual runs for existing tags so a failed release can be recovered after a workflow-only fix.
+
+## Recovery: Release Please opens a wrong major-version PR
+
+If Release Please opens a PR that backfills old history and proposes an unintended major version:
+
+1. Do not merge the PR.
+2. Check whether the version in `.release-please-manifest.json` has a matching Git tag and GitHub Release.
+3. If the previous release was recovered manually, anchor Release Please to the recovered release PR/tag point using `last-release-sha` in `release-please-config.json`.
+4. Close the incorrect Release Please PR.
+5. Let Release Please run again on the next push to `main`.
+
+## Manual verification commands
+
+Check PyPI:
+
+```bash
+curl -fsSL https://pypi.org/pypi/tripwire-py/<version>/json >/dev/null
+```
+
+Check GitHub release:
+
+```bash
+curl -fsSL \
+  -H "Authorization: Bearer ${GH_TOKEN:-${GITHUB_TOKEN:-}}" \
+  -H 'Accept: application/vnd.github+json' \
+  https://api.github.com/repos/Daily-Nerd/TripWire/releases/tags/v<version> >/dev/null
+```
+
+Check Release Please state:
+
+```bash
+python .github/scripts/validate_release_config.py
+```


### PR DESCRIPTION
This PR hardens the release process and adds docs:

- docs/RELEASING.md: normal + recovery flows, required secrets/environments, manual verification steps.
- .github/scripts/validate_release_config.py: validates Release Please/manifest/workflows.
- .github/workflows/release-config-validate.yml: CI job to run the validator on pushes/PRs that touch release files.
- release-please.yml: drop unnecessary id-token permission.

Outcome:
- Prevents regressions that previously caused missing tags or incorrect major bumps.
- Documents the recovery path when a release PR was merged but publish failed.
